### PR TITLE
Add possibility to customize the gauge type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target/
 /.idea/
 /SteelSeries.iml
+.classpath
+.project
+.settings/

--- a/src/main/java/eu/hansolo/steelseries/gauges/AbstractRadial.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/AbstractRadial.java
@@ -30,6 +30,7 @@ package eu.hansolo.steelseries.gauges;
 import eu.hansolo.steelseries.tools.ColorDef;
 import eu.hansolo.steelseries.tools.ConicalGradientPaint;
 import eu.hansolo.steelseries.tools.CustomColorDef;
+import eu.hansolo.steelseries.tools.CustomGaugeType;
 import eu.hansolo.steelseries.tools.Direction;
 import eu.hansolo.steelseries.tools.ForegroundType;
 import eu.hansolo.steelseries.tools.FrameType;
@@ -43,16 +44,7 @@ import eu.hansolo.steelseries.tools.PointerType;
 import eu.hansolo.steelseries.tools.PostPosition;
 import eu.hansolo.steelseries.tools.TicklabelOrientation;
 import eu.hansolo.steelseries.tools.Util;
-import org.pushingpixels.trident.Timeline;
-import org.pushingpixels.trident.TimelineScenario;
-import org.pushingpixels.trident.callback.TimelineCallback;
-import org.pushingpixels.trident.ease.Sine;
-import org.pushingpixels.trident.ease.Spline;
-import org.pushingpixels.trident.ease.TimelineEase;
 
-import javax.swing.SwingConstants;
-import javax.swing.Timer;
-import javax.swing.border.Border;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Container;
@@ -80,6 +72,17 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.util.Arrays;
 import java.util.List;
+
+import javax.swing.SwingConstants;
+import javax.swing.Timer;
+import javax.swing.border.Border;
+
+import org.pushingpixels.trident.Timeline;
+import org.pushingpixels.trident.TimelineScenario;
+import org.pushingpixels.trident.callback.TimelineCallback;
+import org.pushingpixels.trident.ease.Sine;
+import org.pushingpixels.trident.ease.Spline;
+import org.pushingpixels.trident.ease.TimelineEase;
 
 
 /**
@@ -152,22 +155,44 @@ public abstract class AbstractRadial extends AbstractGauge implements Lcd {
     // <editor-fold defaultstate="collapsed" desc="Getters and Setters">
     /**
      * Returns the enum that defines the type of the gauge
-     * FG_TYPE1    a quarter gauge (90 deg)
-     * FG_TYPE2    a two quarter gauge (180 deg)
-     * FG_TYPE3    a three quarter gauge (270 deg)
+     * TYPE1    a quarter gauge (90 deg)
+     * TYPE2    a two quarter gauge (180 deg)
+     * TYPE3    a three quarter gauge (270 deg)
      * TYPE4    a four quarter gauge (300 deg)
+     * CUSTOM   see {@link #getCustomGaugeType() getCustomGaugeType}
      * @return the type of the gauge (90, 180, 270 or 300 deg)
      */
     public GaugeType getGaugeType() {
         return getModel().getGaugeType();
     }
+    
+    /**
+     * Returns the custom type of the radial gauge.
+     * @return the custom type of the radial gauge.
+     */
+    public CustomGaugeType getCustomGaugeType() {
+        return getModel().getCustomGaugeType();
+    }
+    
+    /**
+     * Sets the custom radial type of the gauge.
+     * Set the gauge type to {@link GaugeType#CUSTOM CUSTOM}.
+     * @param CUSTOM_GAUGE_TYPE
+     */
+    public void setCustomGaugeType(CustomGaugeType CUSTOM_GAUGE_TYPE)
+    {
+        getModel().setCustomGaugeType(CUSTOM_GAUGE_TYPE);
+        init(getInnerBounds().width, getInnerBounds().height);
+        repaint(getInnerBounds());
+    }
 
     /**
      * Sets the type of the gauge
-     * FG_TYPE1    a quarter gauge (90 deg)
-     * FG_TYPE2    a two quarter gauge (180 deg)
-     * FG_TYPE3    a three quarter gauge (270 deg)
+     * TYPE1    a quarter gauge (90 deg)
+     * TYPE2    a two quarter gauge (180 deg)
+     * TYPE3    a three quarter gauge (270 deg)
      * TYPE4    a four quarter gauge (300 deg)
+     * CUSTOM   set the {@link #setCustomGaugeType(CustomGaugeType) custom gauge type}.
      * @param GAUGE_TYPE
      */
     public void setGaugeType(final GaugeType GAUGE_TYPE) {

--- a/src/main/java/eu/hansolo/steelseries/gauges/Radial.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/Radial.java
@@ -193,7 +193,7 @@ public class Radial extends AbstractRadial {
         }
 
         if (getPostsVisible()) {
-            createPostsImage(GAUGE_WIDTH, fImage, getGaugeType().POST_POSITIONS);
+            createPostsImage(GAUGE_WIDTH, fImage, getModel().getPostPosition());
         } else {
             createPostsImage(GAUGE_WIDTH, fImage, new PostPosition[]{PostPosition.CENTER});
         }
@@ -230,6 +230,7 @@ public class Radial extends AbstractRadial {
                                                        getModel().getMinorTickSpacing(),
                                                        getModel().getMajorTickSpacing(),
                                                        getGaugeType(),
+                                                       getCustomGaugeType(),
                                                        getMinorTickmarkType(),
                                                        getMajorTickmarkType(),
                                                        isTickmarksVisible(),
@@ -258,15 +259,15 @@ public class Radial extends AbstractRadial {
 
         if (isLcdVisible()) {
             if (isLcdBackgroundVisible()) {
-            createLcdImage(new Rectangle2D.Double(((getGaugeBounds().width - GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getX()) / 2.0),
-                             (getGaugeBounds().height * getGaugeType().LCD_FACTORS.getY()),
-                             (GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getWidth()),
-                             (GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getHeight())),
+            createLcdImage(new Rectangle2D.Double(((getGaugeBounds().width - GAUGE_WIDTH * getModel().getLcdFactors().getX()) / 2.0),
+                             (getGaugeBounds().height * getModel().getLcdFactors().getY()),
+                             (GAUGE_WIDTH * getModel().getLcdFactors().getWidth()),
+                             (GAUGE_WIDTH * getModel().getLcdFactors().getHeight())),
                              getLcdColor(),
                              getCustomLcdBackground(),
                              bImage);
             }
-            LCD.setRect(((getGaugeBounds().width - GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getX()) / 2.0), (getGaugeBounds().height * getGaugeType().LCD_FACTORS.getY()), GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getWidth(), GAUGE_WIDTH * getGaugeType().LCD_FACTORS.getHeight());
+            LCD.setRect(((getGaugeBounds().width - GAUGE_WIDTH * getModel().getLcdFactors().getX()) / 2.0), (getGaugeBounds().height * getModel().getLcdFactors().getY()), GAUGE_WIDTH * getModel().getLcdFactors().getWidth(), GAUGE_WIDTH * getModel().getLcdFactors().getHeight());
             lcdArea = new Area(LCD);
 
             // Create the lcd threshold indicator image
@@ -629,9 +630,9 @@ public class Radial extends AbstractRadial {
         if (bImage != null) {
             final double ANGLE_STEP;
             if (!isLogScale()) {
-                ANGLE_STEP = Math.toDegrees(getGaugeType().ANGLE_RANGE) / (getMaxValue() - getMinValue());
+                ANGLE_STEP = Math.toDegrees(getModel().getAngleRange()) / (getMaxValue() - getMinValue());
             } else {
-                ANGLE_STEP = Math.toDegrees(getGaugeType().ANGLE_RANGE) / UTIL.logOfBase(BASE, (getMaxValue() - getMinValue()));
+                ANGLE_STEP = Math.toDegrees(getModel().getAngleRange()) / UTIL.logOfBase(BASE, (getMaxValue() - getMinValue()));
             }
 
             if (bImage != null && !getAreas().isEmpty()) {
@@ -646,9 +647,9 @@ public class Radial extends AbstractRadial {
                 final Rectangle2D AREA_FRAME = new Rectangle2D.Double(bImage.getMinX() + FREE_AREA, bImage.getMinY() + FREE_AREA, 2 * RADIUS, 2 * RADIUS);
                 for (Section area : getAreas()) {
                     if (!isLogScale()) {
-                        area.setFilledArea(new Arc2D.Double(AREA_FRAME, getGaugeType().ORIGIN_CORRECTION - (area.getStart() * ANGLE_STEP) + (getMinValue() * ANGLE_STEP), -(area.getStop() - area.getStart()) * ANGLE_STEP, Arc2D.PIE));
+                        area.setFilledArea(new Arc2D.Double(AREA_FRAME, getModel().getOriginCorrection() - (area.getStart() * ANGLE_STEP) + (getMinValue() * ANGLE_STEP), -(area.getStop() - area.getStart()) * ANGLE_STEP, Arc2D.PIE));
                     } else {
-                        area.setFilledArea(new Arc2D.Double(AREA_FRAME, getGaugeType().ORIGIN_CORRECTION - (UTIL.logOfBase(BASE, area.getStart()) * ANGLE_STEP) + (UTIL.logOfBase(BASE, getMinValue()) * ANGLE_STEP), -UTIL.logOfBase(BASE, area.getStop() - area.getStart()) * ANGLE_STEP, Arc2D.PIE));
+                        area.setFilledArea(new Arc2D.Double(AREA_FRAME, getModel().getOriginCorrection() - (UTIL.logOfBase(BASE, area.getStart()) * ANGLE_STEP) + (UTIL.logOfBase(BASE, getMinValue()) * ANGLE_STEP), -UTIL.logOfBase(BASE, area.getStop() - area.getStart()) * ANGLE_STEP, Arc2D.PIE));
                     }
                 }
             }
@@ -676,9 +677,9 @@ public class Radial extends AbstractRadial {
         if (bImage != null) {
             final double ANGLE_STEP;
             if (!isLogScale()) {
-                ANGLE_STEP = getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue());
+                ANGLE_STEP = getModel().getApexAngle() / (getMaxValue() - getMinValue());
             } else {
-                ANGLE_STEP = getGaugeType().APEX_ANGLE / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
+                ANGLE_STEP = getModel().getApexAngle() / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
             }
 
             final double OUTER_RADIUS = bImage.getWidth() * 0.38f;
@@ -692,10 +693,10 @@ public class Radial extends AbstractRadial {
                 final double ANGLE_EXTEND;
 
                 if (!isLogScale()) {
-                    ANGLE_START = getGaugeType().ORIGIN_CORRECTION - (section.getStart() * ANGLE_STEP) + (getMinValue() * ANGLE_STEP);
+                    ANGLE_START = getModel().getOriginCorrection() - (section.getStart() * ANGLE_STEP) + (getMinValue() * ANGLE_STEP);
                     ANGLE_EXTEND = -(section.getStop() - section.getStart()) * ANGLE_STEP;
                 } else {
-                    ANGLE_START = getGaugeType().ORIGIN_CORRECTION - (UTIL.logOfBase(BASE, section.getStart())) * ANGLE_STEP + (UTIL.logOfBase(BASE, getMinValue())) * ANGLE_STEP;
+                    ANGLE_START = getModel().getOriginCorrection() - (UTIL.logOfBase(BASE, section.getStart())) * ANGLE_STEP + (UTIL.logOfBase(BASE, getMinValue())) * ANGLE_STEP;
                     ANGLE_EXTEND = -UTIL.logOfBase(BASE, section.getStop() - section.getStart()) * ANGLE_STEP;
                 }
 

--- a/src/main/java/eu/hansolo/steelseries/gauges/Radial1Square.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/Radial1Square.java
@@ -263,6 +263,7 @@ public final class Radial1Square extends AbstractRadial {
                                                        getModel().getMinorTickSpacing(),
                                                        getModel().getMajorTickSpacing(),
                                                        getGaugeType(),
+                                                       getCustomGaugeType(),
                                                        getMinorTickmarkType(),
                                                        getMajorTickmarkType(),
                                                        isTickmarksVisible(),

--- a/src/main/java/eu/hansolo/steelseries/gauges/Radial1Vertical.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/Radial1Vertical.java
@@ -194,6 +194,7 @@ public final class Radial1Vertical extends AbstractRadial {
                                                                         getModel().getMinorTickSpacing(),
                                                                         getModel().getMajorTickSpacing(),
                                                                         getGaugeType(),
+                                                                        getCustomGaugeType(),
                                                                         getMinorTickmarkType(),
                                                                         getMajorTickmarkType(),
                                                                         isTickmarksVisible(),
@@ -412,9 +413,9 @@ public final class Radial1Vertical extends AbstractRadial {
         // Draw threshold indicator
         if (isThresholdVisible()) {
             if (!isLogScale()) {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + (getThreshold() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + (getThreshold() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             } else {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + UTIL.logOfBase(BASE, getThreshold() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + UTIL.logOfBase(BASE, getThreshold() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             }
             G2.drawImage(thresholdImage, 0, 0, null);
             G2.setTransform(FORMER_TRANSFORM);
@@ -423,9 +424,9 @@ public final class Radial1Vertical extends AbstractRadial {
         // Draw min measured value indicator
         if (isMinMeasuredValueVisible()) {
             if (!isLogScale()) {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + (getMinMeasuredValue() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + (getMinMeasuredValue() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             } else {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + UTIL.logOfBase(BASE, getMinMeasuredValue() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + UTIL.logOfBase(BASE, getMinMeasuredValue() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             }
             G2.drawImage(minMeasuredImage, 0, 0, null);
             G2.setTransform(FORMER_TRANSFORM);
@@ -434,9 +435,9 @@ public final class Radial1Vertical extends AbstractRadial {
         // Draw max measured value indicator
         if (isMaxMeasuredValueVisible()) {
             if (!isLogScale()) {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + (getMaxMeasuredValue() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + (getMaxMeasuredValue() - getMinValue()) * getAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             } else {
-                G2.rotate(getGaugeType().ROTATION_OFFSET + UTIL.logOfBase(BASE, getMaxMeasuredValue() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
+                G2.rotate(getRotationOffset() + UTIL.logOfBase(BASE, getMaxMeasuredValue() - getMinValue()) * getLogAngleStep(), CENTER.getX(), getGaugeBounds().width * 0.7336448598);
             }
             G2.drawImage(maxMeasuredImage, 0, 0, null);
             G2.setTransform(FORMER_TRANSFORM);
@@ -458,9 +459,9 @@ public final class Radial1Vertical extends AbstractRadial {
 
         // Draw the pointer
         if (!isLogScale()) {
-            angle = getGaugeType().ROTATION_OFFSET + (getValue() - getMinValue()) * getAngleStep();
+            angle = getRotationOffset() + (getValue() - getMinValue()) * getAngleStep();
         } else {
-            angle = getGaugeType().ROTATION_OFFSET + UTIL.logOfBase(BASE, getValue() - getMinValue()) * getLogAngleStep();
+            angle = getRotationOffset() + UTIL.logOfBase(BASE, getValue() - getMinValue()) * getLogAngleStep();
         }
         //G2.rotate(ANGLE + (Math.cos(Math.toRadians(ANGLE - ROTATION_OFFSET - 91.5))), CENTER.getX(), backgroundImage.getHeight() * 0.7336448598);
         G2.rotate(angle, CENTER.getX(), getGaugeBounds().height * 0.7336448598 + 2);
@@ -584,9 +585,9 @@ public final class Radial1Vertical extends AbstractRadial {
 
         if (bImage != null) {
             if (!isLogScale()) {
-                ANGLE_STEP = Math.toDegrees(getGaugeType().ANGLE_RANGE) / (getMaxValue() - getMinValue());
+                ANGLE_STEP = Math.toDegrees(getModel().getAngleRange()) / (getMaxValue() - getMinValue());
             } else {
-                ANGLE_STEP = Math.toDegrees(getGaugeType().ANGLE_RANGE) / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
+                ANGLE_STEP = Math.toDegrees(getModel().getAngleRange()) / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
             }
 
             if (bImage != null && !getAreas().isEmpty()) {
@@ -662,9 +663,9 @@ public final class Radial1Vertical extends AbstractRadial {
 
             final double ANGLE_STEP;
             if (!isLogScale()) {
-                ANGLE_STEP = getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue());
+                ANGLE_STEP = getModel().getApexAngle() / (getMaxValue() - getMinValue());
             } else {
-                ANGLE_STEP = getGaugeType().APEX_ANGLE / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
+                ANGLE_STEP = getModel().getApexAngle() / UTIL.logOfBase(BASE, getMaxValue() - getMinValue());
             }
 
             final double OUTER_RADIUS = bImage.getWidth() * 0.44f;

--- a/src/main/java/eu/hansolo/steelseries/gauges/Radial2Top.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/Radial2Top.java
@@ -39,6 +39,7 @@ import eu.hansolo.steelseries.tools.Scaler;
 import eu.hansolo.steelseries.tools.Section;
 import eu.hansolo.steelseries.tools.Shadow;
 import eu.hansolo.steelseries.tools.Util;
+
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -207,6 +208,7 @@ public final class Radial2Top extends AbstractRadial {
                                                        getModel().getMinorTickSpacing(),
                                                        getModel().getMajorTickSpacing(),
                                                        getGaugeType(),
+                                                       getCustomGaugeType(),
                                                        getMinorTickmarkType(),
                                                        getMajorTickmarkType(),
                                                        isTickmarksVisible(),

--- a/src/main/java/eu/hansolo/steelseries/gauges/RadialBargraph.java
+++ b/src/main/java/eu/hansolo/steelseries/gauges/RadialBargraph.java
@@ -35,6 +35,7 @@ import eu.hansolo.steelseries.tools.NumberSystem;
 import eu.hansolo.steelseries.tools.Orientation;
 import eu.hansolo.steelseries.tools.Section;
 import eu.hansolo.steelseries.tools.Util;
+
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics;
@@ -100,8 +101,8 @@ public class RadialBargraph extends AbstractRadialBargraph {
         sectionGradients = new java.util.HashMap<Section, RadialGradientPaint>(4);
         sectionAngles = new java.util.HashMap<Section, Point2D>(4);
 
-        ledTrackStartAngle = getGaugeType().ORIGIN_CORRECTION - (0 * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue())));
-        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue()));
+        ledTrackStartAngle = getModel().getOriginCorrection() - (0 * (getModel().getApexAngle() / (getMaxValue() - getMinValue())));
+        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getModel().getApexAngle() / (getMaxValue() - getMinValue()));
         calcBargraphTrack();
         prepareBargraph(getInnerBounds().width);
         setLcdVisible(true);
@@ -121,8 +122,8 @@ public class RadialBargraph extends AbstractRadialBargraph {
         sectionGradients = new java.util.HashMap<Section, RadialGradientPaint>(4);
         sectionAngles = new java.util.HashMap<Section, Point2D>(4);
 
-        ledTrackStartAngle = getGaugeType().ORIGIN_CORRECTION - (0 * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue())));
-        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue()));
+        ledTrackStartAngle = getModel().getOriginCorrection() - (0 * (getModel().getApexAngle() / (getMaxValue() - getMinValue())));
+        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getModel().getApexAngle() / (getMaxValue() - getMinValue()));
         calcBargraphTrack();
         prepareBargraph(getGaugeBounds().width);
     }
@@ -161,8 +162,8 @@ public class RadialBargraph extends AbstractRadialBargraph {
 
             setLcdInfoFont(getModel().getStandardInfoFont().deriveFont(0.15f * GAUGE_WIDTH * 0.15f));
         }
-        ledTrackStartAngle = getGaugeType().ORIGIN_CORRECTION - (0 * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue())));
-        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue()));
+        ledTrackStartAngle = getModel().getOriginCorrection() - (0 * (getModel().getApexAngle() / (getMaxValue() - getMinValue())));
+        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getModel().getApexAngle() / (getMaxValue() - getMinValue()));
 
         calcBargraphTrack();
         prepareBargraph(getGaugeBounds().width);
@@ -210,7 +211,7 @@ public class RadialBargraph extends AbstractRadialBargraph {
             setGlowPulsating(false);
         }
 
-        create_BARGRAPH_TRACK_Image(GAUGE_WIDTH, ledTrackStartAngle, ledTrackAngleExtend, getGaugeType().APEX_ANGLE, getGaugeType().BARGRAPH_OFFSET, bImage);
+        create_BARGRAPH_TRACK_Image(GAUGE_WIDTH, ledTrackStartAngle, ledTrackAngleExtend, getModel().getApexAngle(), getModel().getBargraphOffset(), bImage);
 
         create_TITLE_Image(GAUGE_WIDTH, getTitle(), getUnitString(), bImage);
 
@@ -235,6 +236,7 @@ public class RadialBargraph extends AbstractRadialBargraph {
                                                        getModel().getMinorTickSpacing(),
                                                        getModel().getMajorTickSpacing(),
                                                        getGaugeType(),
+                                                       getCustomGaugeType(),
                                                        getMinorTickmarkType(),
                                                        getMajorTickmarkType(),
                                                        false,
@@ -383,7 +385,7 @@ public class RadialBargraph extends AbstractRadialBargraph {
 
         if (!getModel().isSingleLedBargraphEnabled()) {
             for (double angle = 0; Double.compare(angle, ACTIVE_LED_ANGLE) <= 0; angle += 5.0) {
-                G2.rotate(Math.toRadians(angle + getGaugeType().BARGRAPH_OFFSET), CENTER.getX(), CENTER.getY());
+                G2.rotate(Math.toRadians(angle + getModel().getBargraphOffset()), CENTER.getX(), CENTER.getY());
                 // If sections visible, color the bargraph with the given section colors
                 G2.setPaint(ledGradient);
                 if (isSectionsVisible()) {
@@ -401,7 +403,7 @@ public class RadialBargraph extends AbstractRadialBargraph {
                 G2.setTransform(OLD_TRANSFORM);
             }
         } else {   // Draw only one led instead of all active leds
-            final double ANGLE = Math.toRadians(((getValue() - getMinValue()) / (getMaxValue() - getMinValue())) * getGaugeType().APEX_ANGLE);
+            final double ANGLE = Math.toRadians(((getValue() - getMinValue()) / (getMaxValue() - getMinValue())) * getModel().getApexAngle());
             G2.rotate(ANGLE, CENTER.getX(), CENTER.getY());
             if (isSectionsVisible()) {
                 for (Section section : getSections()) {
@@ -419,7 +421,7 @@ public class RadialBargraph extends AbstractRadialBargraph {
 
         // Draw peak value if enabled
         if (isPeakValueEnabled() && isPeakValueVisible()) {
-            G2.rotate(Math.toRadians(((getPeakValue() - getMinValue()) / (getMaxValue() - getMinValue())) * getGaugeType().APEX_ANGLE + getGaugeType().BARGRAPH_OFFSET), CENTER.getX(), CENTER.getY());
+            G2.rotate(Math.toRadians(((getPeakValue() - getMinValue()) / (getMaxValue() - getMinValue())) * getModel().getApexAngle() + getModel().getBargraphOffset()), CENTER.getX(), CENTER.getY());
             G2.fill(led);
             G2.setTransform(OLD_TRANSFORM);
         }
@@ -495,12 +497,12 @@ public class RadialBargraph extends AbstractRadialBargraph {
     }
 
     private void calcBargraphTrack() {
-        ledTrackStartAngle = getGaugeType().ORIGIN_CORRECTION;
-        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getGaugeType().APEX_ANGLE / (getMaxValue() - getMinValue()));
+        ledTrackStartAngle = getModel().getOriginCorrection();
+        ledTrackAngleExtend = -(getMaxValue() - getMinValue()) * (getModel().getApexAngle() / (getMaxValue() - getMinValue()));
     }
 
     private double getAngleForValue(double value) {
-        return ((value - getMinValue()) / (getMaxValue() - getMinValue())) * getGaugeType().APEX_ANGLE;
+        return ((value - getMinValue()) / (getMaxValue() - getMinValue())) * getModel().getApexAngle();
     }
 
     @Override

--- a/src/main/java/eu/hansolo/steelseries/tools/CustomGaugeType.java
+++ b/src/main/java/eu/hansolo/steelseries/tools/CustomGaugeType.java
@@ -29,19 +29,8 @@ package eu.hansolo.steelseries.tools;
 
 import java.awt.geom.Rectangle2D;
 
-
-/**
- *
- * @author Gerrit Grunwald <han.solo at muenster.de>
- */
-public enum GaugeType {
-
-    TYPE1(0, (1.5 * Math.PI), (0.5 * Math.PI), (Math.PI * 0.5), (Math.PI / 2.0), 180, 90, 0, new Rectangle2D.Double(0.55, 0.55, 0.55, 0.15), PostPosition.CENTER, PostPosition.MAX_CENTER_TOP, PostPosition.MIN_LEFT),
-    TYPE2(0, (1.5 * Math.PI), (0.5 * Math.PI), (Math.PI * 0.5), Math.PI, 180, 180, 0, new Rectangle2D.Double(0.55, 0.55, 0.55, 0.15), PostPosition.CENTER, PostPosition.MIN_LEFT, PostPosition.MAX_RIGHT),
-    TYPE3(0, Math.PI, 0, Math.PI, (1.5 * Math.PI), 270, 270, -90, new Rectangle2D.Double(0.4, 0.55, 0.4, 0.15), PostPosition.CENTER, PostPosition.MAX_CENTER_BOTTOM, PostPosition.MAX_RIGHT),
-    TYPE4((Math.toRadians(60)), (Math.PI + Math.toRadians(30)), 0, Math.PI - Math.toRadians(30), Math.toRadians(300), 240, 300, -60, new Rectangle2D.Double(0.4, 0.55, 0.4, 0.15), PostPosition.CENTER, PostPosition.MIN_BOTTOM, PostPosition.MAX_BOTTOM),
-    TYPE5(0, (1.75 * Math.PI), (0.75 * Math.PI), (Math.PI * 0.5), (Math.PI * 0.5), 180, 90, 0, new Rectangle2D.Double(0.55, 0.55, 0.55, 0.15), PostPosition.LOWER_CENTER, PostPosition.SMALL_GAUGE_MIN_LEFT, PostPosition.SMALL_GAUGE_MAX_RIGHT),
-    CUSTOM(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, null);
+public class CustomGaugeType
+{
     final public double FREE_AREA_ANGLE;
     final public double ROTATION_OFFSET;
     final public double TICKMARK_OFFSET;
@@ -52,11 +41,10 @@ public enum GaugeType {
     final public double BARGRAPH_OFFSET;
     final public PostPosition[] POST_POSITIONS;
     final public Rectangle2D LCD_FACTORS;
-
-    private GaugeType(final double FREE_AREA_ANGLE, final double ROTATION_OFFSET, final double TICKMARK_OFFSET, final double TICKLABEL_ORIENTATION_CHANGE_ANGLE,
-                      final double ANGLE_RANGE, final double ORIGIN_CORRECTION, final double APEX_ANGLE,
-                      final double BARGRAPH_OFFSET, final Rectangle2D LCD_FACTORS,
-                      final PostPosition... POST_POSITIONS) {
+    
+    public CustomGaugeType(double FREE_AREA_ANGLE, double ROTATION_OFFSET, double TICKMARK_OFFSET, double TICKLABEL_ORIENTATION_CHANGE_ANGLE, double ANGLE_RANGE, double ORIGIN_CORRECTION, double APEX_ANGLE, double BARGRAPH_OFFSET, Rectangle2D LCD_FACTORS, PostPosition... POST_POSITIONS)
+    {
+        super();
         this.FREE_AREA_ANGLE = FREE_AREA_ANGLE;
         this.ROTATION_OFFSET = ROTATION_OFFSET;
         this.TICKMARK_OFFSET = TICKMARK_OFFSET;
@@ -65,7 +53,37 @@ public enum GaugeType {
         this.ORIGIN_CORRECTION = ORIGIN_CORRECTION;
         this.APEX_ANGLE = APEX_ANGLE;
         this.BARGRAPH_OFFSET = BARGRAPH_OFFSET;
-        this.POST_POSITIONS = POST_POSITIONS;
         this.LCD_FACTORS = LCD_FACTORS;
+        this.POST_POSITIONS = POST_POSITIONS;
+    }
+    
+    /**
+     * Create a custom gauge type with the given range starting at the given offset.
+     * 
+     * @param RANGE the range in degree.
+     * @param OFFSET the offset in degree.
+     * @param POST_POSITIONS
+     */
+    public CustomGaugeType(double RANGE, double OFFSET, PostPosition... POST_POSITIONS)
+    {
+        this.FREE_AREA_ANGLE = 2 * Math.PI - Math.toRadians(RANGE);
+        this.ROTATION_OFFSET = Math.toRadians(OFFSET);
+        this.TICKMARK_OFFSET = 0;
+        this.TICKLABEL_ORIENTATION_CHANGE_ANGLE = Math.PI / 2;
+        this.ANGLE_RANGE = Math.toRadians(RANGE);
+        //Compute the origin correction
+        final double offset = OFFSET % 360;
+        if (offset <= 45 || offset >= 270)
+        {
+            this.ORIGIN_CORRECTION = (-OFFSET + 90) % 360;
+        }
+        else
+        {
+            this.ORIGIN_CORRECTION = (-OFFSET - 270) % 360;
+        }
+        this.APEX_ANGLE = RANGE;
+        this.BARGRAPH_OFFSET = 0;
+        this.LCD_FACTORS = new Rectangle2D.Double(0.4, 0.55, 0.4, 0.15);
+        this.POST_POSITIONS = POST_POSITIONS;
     }
 }

--- a/src/main/java/eu/hansolo/steelseries/tools/TickmarkImageFactory.java
+++ b/src/main/java/eu/hansolo/steelseries/tools/TickmarkImageFactory.java
@@ -67,6 +67,7 @@ public enum TickmarkImageFactory {
     private double minorTickSpacingBufferRad = 10;
     private double majorTickSpacingBufferRad = 10;
     private GaugeType gaugeTypeBufferRad = GaugeType.TYPE4;
+    private CustomGaugeType customGaugeTypeBufferRad = null;
     private TickmarkType minorTickmarkTypeBufferRad = TickmarkType.LINE;
     private TickmarkType majorTickmarkTypeBufferRad = TickmarkType.LINE;
     private boolean ticksVisibleBufferRad = true;
@@ -126,6 +127,7 @@ public enum TickmarkImageFactory {
                                                           final double MINOR_TICK_SPACING,
                                                           final double MAJOR_TICK_SPACING,
                                                           final GaugeType GAUGE_TYPE,
+                                                          final CustomGaugeType CUSTOM_GAUGE_TYPE,
                                                           final TickmarkType MINOR_TICKMARK_TYPE,
                                                           final TickmarkType MAJOR_TICKMARK_TYPE,
                                                           final boolean TICKS_VISIBLE,
@@ -162,6 +164,7 @@ public enum TickmarkImageFactory {
             && Double.compare(MINOR_TICK_SPACING, minorTickSpacingBufferRad) == 0
             && Double.compare(MAJOR_TICK_SPACING, majorTickSpacingBufferRad) == 0
             && GAUGE_TYPE == gaugeTypeBufferRad
+            && CUSTOM_GAUGE_TYPE == customGaugeTypeBufferRad
             && MINOR_TICKMARK_TYPE == minorTickmarkTypeBufferRad
             && MAJOR_TICKMARK_TYPE == majorTickmarkTypeBufferRad
             && TICKS_VISIBLE == ticksVisibleBufferRad
@@ -230,9 +233,10 @@ public enum TickmarkImageFactory {
         final Line2D TICK_LINE = new Line2D.Double(0, 0, 1, 1);
         final Ellipse2D TICK_CIRCLE = new Ellipse2D.Double(0, 0, 1, 1);
         final GeneralPath TICK_TRIANGLE = new GeneralPath();
-        final double ROTATION_OFFSET = GAUGE_TYPE.ROTATION_OFFSET; // Depends on GaugeType
+        final double ROTATION_OFFSET = GAUGE_TYPE == GaugeType.CUSTOM ? CUSTOM_GAUGE_TYPE.ROTATION_OFFSET : GAUGE_TYPE.ROTATION_OFFSET; // Depends on GaugeType
         final float RADIUS = WIDTH * RADIUS_FACTOR;
-        final double ANGLE_STEP = (GAUGE_TYPE.ANGLE_RANGE / ((MAX_VALUE - MIN_VALUE) / MINOR_TICK_SPACING));
+        final double angleRange = GAUGE_TYPE == GaugeType.CUSTOM ? CUSTOM_GAUGE_TYPE.ANGLE_RANGE : GAUGE_TYPE.ANGLE_RANGE;
+        final double ANGLE_STEP = (angleRange / ((MAX_VALUE - MIN_VALUE) / MINOR_TICK_SPACING));
         double sinValue;
         double cosValue;
         double valueCounter = MIN_VALUE;
@@ -269,7 +273,7 @@ public enum TickmarkImageFactory {
                 OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
                 TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
                 drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
-                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(MIN_VALUE), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET));
+                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(MIN_VALUE), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET));
 
                 // Max Value
                 alpha = -(MAX_VALUE - MIN_VALUE) * ANGLE_STEP;
@@ -280,7 +284,7 @@ public enum TickmarkImageFactory {
                 OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
                 TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
                 drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
-                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(MAX_VALUE), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET));
+                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(MAX_VALUE), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET));
 
                 for (Section section : sections) {
                     // Section start
@@ -292,7 +296,7 @@ public enum TickmarkImageFactory {
                     OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
                     TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
                     drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
-                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(section.getStart()), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET));
+                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(section.getStart()), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET));
 
                     // Section stop
                     alpha = -(section.getStop() - MIN_VALUE) * ANGLE_STEP;
@@ -303,167 +307,172 @@ public enum TickmarkImageFactory {
                     OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
                     TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
                     drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
-                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(section.getStop()), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET));
+                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(section.getStop()), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET));
                 }
 
-        } else if(!LOG_SCALE) {
-            for (double alpha = 0, counter = MIN_VALUE; Double.compare(counter, MAX_VALUE) <= 0; alpha -= ANGLE_STEP, counter += MINOR_TICK_SPACING) {
-                // Set the color
-                if (tickmarkSections != null && !tickmarkSections.isEmpty()) {
-                    if (TICKMARK_SECTIONS_VISIBLE) {
-                        for (Section section : tickmarkSections) {
-                            if (Double.compare(valueCounter, section.getStart()) >= 0 && Double.compare(valueCounter, section.getStop()) <= 0) {
-                                G2.setColor(Util.INSTANCE.setAlpha(section.getColor(), 1.0f));
-                                break;
-                            } else if (TICKMARK_COLOR_FROM_THEME) {
+        }
+        else
+        {
+            final double tickLabelOrientationChangeAngle = GAUGE_TYPE == GaugeType.CUSTOM ? CUSTOM_GAUGE_TYPE.TICKLABEL_ORIENTATION_CHANGE_ANGLE : GAUGE_TYPE.TICKLABEL_ORIENTATION_CHANGE_ANGLE;
+            if(!LOG_SCALE) {
+                for (double alpha = 0, counter = MIN_VALUE; Double.compare(counter, MAX_VALUE) <= 0; alpha -= ANGLE_STEP, counter += MINOR_TICK_SPACING) {
+                    // Set the color
+                    if (tickmarkSections != null && !tickmarkSections.isEmpty()) {
+                        if (TICKMARK_SECTIONS_VISIBLE) {
+                            for (Section section : tickmarkSections) {
+                                if (Double.compare(valueCounter, section.getStart()) >= 0 && Double.compare(valueCounter, section.getStop()) <= 0) {
+                                    G2.setColor(Util.INSTANCE.setAlpha(section.getColor(), 1.0f));
+                                    break;
+                                } else if (TICKMARK_COLOR_FROM_THEME) {
+                                    G2.setColor(BACKGROUND_COLOR.LABEL_COLOR);
+                                } else {
+                                    G2.setColor(TICKMARK_COLOR);
+                                }
+                            }
+                        } else {
+                            if (TICKMARK_COLOR_FROM_THEME) {
                                 G2.setColor(BACKGROUND_COLOR.LABEL_COLOR);
                             } else {
                                 G2.setColor(TICKMARK_COLOR);
                             }
                         }
+                    }
+
+                    sinValue = Math.sin(alpha);
+                    cosValue = Math.cos(alpha);
+                    majorTickCounter++;
+
+                    // Draw tickmark every major tickmark spacing
+                    if (majorTickCounter == NO_OF_MINOR_TICKS) {
+                        G2.setStroke(MAJOR_TICKMARK_STROKE);
+                        INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MAJOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MAJOR_TICK_LENGTH) * cosValue);
+                        OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
+                        TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
+
+                        // Draw the major tickmarks
+                        if (TICKS_VISIBLE && MAJOR_TICKS_VISIBLE) {
+                            drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
+                        }
+
+                        // Draw the standard tickmark labels
+                        if (TICKLABELS_VISIBLE) {
+                            switch(TICKLABEL_ORIENTATION)
+                            {
+                                case NORMAL:
+                                    if (Double.compare(alpha, -tickLabelOrientationChangeAngle) > 0) {
+                                        G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (-Math.PI / 2 - alpha)));
+                                    } else {
+                                        G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI / 2 - alpha)));
+                                    }
+                                    break;
+                                case HORIZONTAL:
+                                    double orientationOffset;
+                                    if (Orientation.WEST == ORIENTATION) {
+                                        orientationOffset = Math.PI / 2;
+                                    } else if (Orientation.EAST == ORIENTATION) {
+                                        orientationOffset = -Math.PI / 2;
+                                    } else if (Orientation.SOUTH == ORIENTATION) {
+                                        orientationOffset = Math.PI;
+                                    } else {
+                                        orientationOffset = 0;
+                                    }
+                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET + orientationOffset));
+                                    break;
+                                case TANGENT:
+
+                                default:
+                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI - alpha + ticklabelRotationOffset)));
+                                    break;
+                            }
+                        }
+
+                        valueCounter += MAJOR_TICK_SPACING;
+                        majorTickCounter = 0;
+                        continue;
+                    }
+
+                    // Draw tickmark every minor tickmark spacing
+                    {
+                        INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MINOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MINOR_TICK_LENGTH) * cosValue);
+                        OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
+                        G2.setStroke(MINOR_TICKMARK_STROKE);
+                        if (NO_OF_MINOR_TICKS % 2 == 0 && majorTickCounter == (NO_OF_MINOR_TICKS / 2)) {
+                            G2.setStroke(MEDIUM_TICKMARK_STROKE);
+                            INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MEDIUM_TICK_LENGTH) * sinValue,
+                                                    CENTER.getY() + (RADIUS - MEDIUM_TICK_LENGTH) * cosValue);
+                            OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
+
+                        }
+
+                        // Draw the minor tickmarks
+                        if (TICKS_VISIBLE && MINOR_TICKS_VISIBLE) {
+                            drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MINOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MINOR_TICK_LENGTH, MINOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
+                        }
+                    }
+                }
+            } else {
+                // ****************************** LOGARITHMIC SCALING ******************************************************
+                final double LOG_ANGLE_STEP = Math.abs(angleRange / UTIL.logOfBase(BASE, (MAX_VALUE - MIN_VALUE)));
+                int exponent = 0;
+                double angle;
+                double valueStep = 1.0;
+                for (double value = 1 ; Double.compare(value, MAX_VALUE) <= 0; value += valueStep) {
+                    if (TICKMARK_COLOR_FROM_THEME) {
+                        G2.setColor(BACKGROUND_COLOR.LABEL_COLOR);
                     } else {
-                        if (TICKMARK_COLOR_FROM_THEME) {
-                            G2.setColor(BACKGROUND_COLOR.LABEL_COLOR);
-                        } else {
-                            G2.setColor(TICKMARK_COLOR);
-                        }
-                    }
-                }
-
-                sinValue = Math.sin(alpha);
-                cosValue = Math.cos(alpha);
-                majorTickCounter++;
-
-                // Draw tickmark every major tickmark spacing
-                if (majorTickCounter == NO_OF_MINOR_TICKS) {
-                    G2.setStroke(MAJOR_TICKMARK_STROKE);
-                    INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MAJOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MAJOR_TICK_LENGTH) * cosValue);
-                    OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
-                    TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
-
-                    // Draw the major tickmarks
-                    if (TICKS_VISIBLE && MAJOR_TICKS_VISIBLE) {
-                        drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MAJOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MAJOR_TICK_LENGTH, MAJOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
+                        G2.setColor(TICKMARK_COLOR);
                     }
 
-                    // Draw the standard tickmark labels
-                    if (TICKLABELS_VISIBLE) {
-                        switch(TICKLABEL_ORIENTATION)
-                        {
-                            case NORMAL:
-                                if (Double.compare(alpha, -GAUGE_TYPE.TICKLABEL_ORIENTATION_CHANGE_ANGLE) > 0) {
-                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (-Math.PI / 2 - alpha)));
-                                } else {
-                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI / 2 - alpha)));
-                                }
-                                break;
-                            case HORIZONTAL:
-                                double orientationOffset;
-                                if (Orientation.WEST == ORIENTATION) {
-                                    orientationOffset = Math.PI / 2;
-                                } else if (Orientation.EAST == ORIENTATION) {
-                                    orientationOffset = -Math.PI / 2;
-                                } else if (Orientation.SOUTH == ORIENTATION) {
-                                    orientationOffset = Math.PI;
-                                } else {
-                                    orientationOffset = 0;
-                                }
-                                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET + orientationOffset));
-                                break;
-                            case TANGENT:
+                    angle = UTIL.logOfBase(BASE, Math.abs(value)) * LOG_ANGLE_STEP;
+                    sinValue = Math.sin(-angle);
+                    cosValue = Math.cos(-angle);
 
-                            default:
-                                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(valueCounter), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI - alpha + ticklabelRotationOffset)));
-                                break;
-                        }
-                    }
-
-                    valueCounter += MAJOR_TICK_SPACING;
-                    majorTickCounter = 0;
-                    continue;
-                }
-
-                // Draw tickmark every minor tickmark spacing
-                {
                     INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MINOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MINOR_TICK_LENGTH) * cosValue);
                     OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
                     G2.setStroke(MINOR_TICKMARK_STROKE);
-                    if (NO_OF_MINOR_TICKS % 2 == 0 && majorTickCounter == (NO_OF_MINOR_TICKS / 2)) {
-                        G2.setStroke(MEDIUM_TICKMARK_STROKE);
-                        INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MEDIUM_TICK_LENGTH) * sinValue,
-                                                CENTER.getY() + (RADIUS - MEDIUM_TICK_LENGTH) * cosValue);
+
+                    if (Double.compare(value, Math.pow(BASE, exponent + 1)) == 0) {
+                        exponent++;
+                        valueStep = Math.pow(BASE, exponent);
+                        INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MAJOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MAJOR_TICK_LENGTH) * cosValue);
                         OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
+                        TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
+                        if (TICKLABELS_VISIBLE) {
+                            switch(TICKLABEL_ORIENTATION)
+                            {
+                                case NORMAL:
+                                    if (Double.compare(value, -tickLabelOrientationChangeAngle) > 0) {
+                                        G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (-Math.PI / 2 + angle)));
+                                    } else {
+                                        G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI / 2 + angle)));
+                                    }
+                                    break;
+                                case HORIZONTAL:
+                                    double orientationOffset;
+                                    if (Orientation.WEST == ORIENTATION) {
+                                        orientationOffset = Math.PI / 2;
+                                    } else if (Orientation.EAST == ORIENTATION) {
+                                        orientationOffset = -Math.PI / 2;
+                                    } else if (Orientation.SOUTH == ORIENTATION) {
+                                        orientationOffset = Math.PI;
+                                    } else {
+                                        orientationOffset = 0;
+                                    }
+                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - ROTATION_OFFSET + orientationOffset));
+                                    break;
+                                case TANGENT:
 
-                    }
-
-                    // Draw the minor tickmarks
-                    if (TICKS_VISIBLE && MINOR_TICKS_VISIBLE) {
-                        drawRadialTicks(G2, INNER_POINT, OUTER_POINT, CENTER, RADIUS, MINOR_TICKMARK_TYPE, TICK_LINE, TICK_CIRCLE, TICK_TRIANGLE, MINOR_TICK_LENGTH, MINOR_DIAMETER, OUTER_POINT_LEFT, OUTER_POINT_RIGHT, alpha);
-                    }
-                }
-            }
-        } else {
-            // ****************************** LOGARITHMIC SCALING ******************************************************
-            final double LOG_ANGLE_STEP = Math.abs(GAUGE_TYPE.ANGLE_RANGE / UTIL.logOfBase(BASE, (MAX_VALUE - MIN_VALUE)));
-            int exponent = 0;
-            double angle;
-            double valueStep = 1.0;
-            for (double value = 1 ; Double.compare(value, MAX_VALUE) <= 0; value += valueStep) {
-                if (TICKMARK_COLOR_FROM_THEME) {
-                    G2.setColor(BACKGROUND_COLOR.LABEL_COLOR);
-                } else {
-                    G2.setColor(TICKMARK_COLOR);
-                }
-
-                angle = UTIL.logOfBase(BASE, Math.abs(value)) * LOG_ANGLE_STEP;
-                sinValue = Math.sin(-angle);
-                cosValue = Math.cos(-angle);
-
-                INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MINOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MINOR_TICK_LENGTH) * cosValue);
-                OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
-                G2.setStroke(MINOR_TICKMARK_STROKE);
-
-                if (Double.compare(value, Math.pow(BASE, exponent + 1)) == 0) {
-                    exponent++;
-                    valueStep = Math.pow(BASE, exponent);
-                    INNER_POINT.setLocation(CENTER.getX() + (RADIUS - MAJOR_TICK_LENGTH) * sinValue, CENTER.getY() + (RADIUS - MAJOR_TICK_LENGTH) * cosValue);
-                    OUTER_POINT.setLocation(CENTER.getX() + RADIUS * sinValue, CENTER.getY() + RADIUS * cosValue);
-                    TEXT_POINT.setLocation(CENTER.getX() + (RADIUS - TEXT_DISTANCE) * sinValue, CENTER.getY() + (RADIUS - TEXT_DISTANCE) * cosValue);
-                    if (TICKLABELS_VISIBLE) {
-                        switch(TICKLABEL_ORIENTATION)
-                        {
-                            case NORMAL:
-                                if (Double.compare(value, -GAUGE_TYPE.TICKLABEL_ORIENTATION_CHANGE_ANGLE) > 0) {
-                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (-Math.PI / 2 + angle)));
-                                } else {
-                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI / 2 + angle)));
-                                }
-                                break;
-                            case HORIZONTAL:
-                                double orientationOffset;
-                                if (Orientation.WEST == ORIENTATION) {
-                                    orientationOffset = Math.PI / 2;
-                                } else if (Orientation.EAST == ORIENTATION) {
-                                    orientationOffset = -Math.PI / 2;
-                                } else if (Orientation.SOUTH == ORIENTATION) {
-                                    orientationOffset = Math.PI;
-                                } else {
-                                    orientationOffset = 0;
-                                }
-                                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), Math.PI - GAUGE_TYPE.ROTATION_OFFSET + orientationOffset));
-                                break;
-                            case TANGENT:
-
-                            default:
-                                G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI + angle + ticklabelRotationOffset)));
-                                break;
+                                default:
+                                    G2.fill(UTIL.rotateTextAroundCenter(G2, numberFormat.format(value), (int) TEXT_POINT.getX(), (int) TEXT_POINT.getY(), (Math.PI + angle + ticklabelRotationOffset)));
+                                    break;
+                            }
                         }
+                        G2.setStroke(MAJOR_TICKMARK_STROKE);
                     }
-                    G2.setStroke(MAJOR_TICKMARK_STROKE);
-                }
-                if (TICKS_VISIBLE && MAJOR_TICKS_VISIBLE && MINOR_TICKS_VISIBLE) {
-                    TICK_LINE.setLine(INNER_POINT, OUTER_POINT);
-                    G2.draw(TICK_LINE);
+                    if (TICKS_VISIBLE && MAJOR_TICKS_VISIBLE && MINOR_TICKS_VISIBLE) {
+                        TICK_LINE.setLine(INNER_POINT, OUTER_POINT);
+                        G2.draw(TICK_LINE);
+                    }
                 }
             }
         }
@@ -484,6 +493,7 @@ public enum TickmarkImageFactory {
         minorTickSpacingBufferRad = MINOR_TICK_SPACING;
         majorTickSpacingBufferRad = MAJOR_TICK_SPACING;
         gaugeTypeBufferRad = GAUGE_TYPE;
+        customGaugeTypeBufferRad = CUSTOM_GAUGE_TYPE;
         minorTickmarkTypeBufferRad = MINOR_TICKMARK_TYPE;
         majorTickmarkTypeBufferRad = MAJOR_TICKMARK_TYPE;
         ticksVisibleBufferRad = TICKS_VISIBLE;


### PR DESCRIPTION
Hello,

I add the possibility to customize the gauge type, in order to choose the range and the offset of a radial view.
* In the enum `GaugeType` the field `CUSTOM` is now present.
* A new class `CustomGaugeType` is added to customize the gauge type. (A simple constructor is made.)
* In `Model` and `AbstractRadial` several getters have been added in order to access the gauge type properties.

Regards
